### PR TITLE
Add saldo adjustment and result persistence

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -3,8 +3,12 @@
 import tkinter as tk
 from tkinter import ttk
 from datetime import datetime
+import json
+import os
 import calendar
 from utils import setup_locale
+
+SAVE_FILE = "last_result.json"
 from budgeting import BudgetCalculator
 
 try:
@@ -21,6 +25,7 @@ class BudgetGUI:
         self.root.title("Budgeting Transportasi Profesional")
         self.root.geometry("1000x700")
         self._build_gui()
+        self._load_last()
 
     def _build_gui(self):
         container = ttk.Frame(self.root, padding=20)
@@ -42,7 +47,11 @@ class BudgetGUI:
         self.month_cb.grid(row=0, column=3, padx=5)
         self._update_months()
 
-        ttk.Button(control, text="Generate", command=self._on_generate).grid(row=0, column=4, padx=20)
+        ttk.Label(control, text="Saldo KMT:").grid(row=0, column=4, sticky='w')
+        self.saldo_var = tk.IntVar(value=0)
+        ttk.Entry(control, textvariable=self.saldo_var, width=10).grid(row=0, column=5, padx=5)
+
+        ttk.Button(control, text="Generate", command=self._on_generate).grid(row=0, column=6, padx=20)
 
         self.notebook = ttk.Notebook(container)
         self.notebook.pack(fill='both', expand=True)
@@ -58,10 +67,14 @@ class BudgetGUI:
         cards = ttk.Frame(self.summary_tab)
         cards.pack(fill='x', pady=10)
         self.card_total = ttk.Label(cards, text='Total: -', font=('Helvetica',16,'bold'))
+        self.card_final = ttk.Label(cards, text='Setelah Saldo: -', font=('Helvetica',14))
         self.card_krl   = ttk.Label(cards, text='KRL: -',   font=('Helvetica',14))
         self.card_krd   = ttk.Label(cards, text='KRD: -',   font=('Helvetica',14))
-        for w in (self.card_total, self.card_krl, self.card_krd):
+        for w in (self.card_total, self.card_final, self.card_krl, self.card_krd):
             w.pack(side='left', expand=True, padx=10)
+
+        self.gen_label = ttk.Label(self.summary_tab, text='')
+        self.gen_label.pack(pady=(0,10))
 
         cols = ('Date','Day','KRL','KRD','Total')
         self.tree = ttk.Treeview(self.details_tab, columns=cols, show='headings')
@@ -96,22 +109,31 @@ class BudgetGUI:
     def _on_generate(self):
         yr    = int(self.year_cb.get())
         mo    = int(self.month_cb.get())
+        saldo = self.saldo_var.get()
         last  = calendar.monthrange(yr,mo)[1]
         day0  = 29 if last>=29 else last
         start = datetime(yr, mo, day0)
         end   = datetime(yr + (mo==12), (mo%12)+1, 28)
         calc  = BudgetCalculator(start, end)
         calc.calculate()
-        self._update_summary(calc)
+        gen_time = datetime.now().strftime('%d-%m-%Y %H:%M')
+        self._update_summary(calc, saldo, gen_time)
         self._update_details(calc)
         if HAS_MPL:
             self._update_charts(calc)
         self.notebook.select(self.summary_tab)
+        self._save_last(calc, saldo, yr, mo, gen_time)
 
-    def _update_summary(self, calc):
+    def _update_summary(self, calc, saldo=0, gen_time=None):
+        final = calc.total - saldo
+        if final < 0:
+            final = 0
         self.card_total.config(text=f"Total: Rp{calc.total:,}")
+        self.card_final.config(text=f"Setelah Saldo: Rp{final:,}")
         self.card_krl.config(text=f"KRL: Rp{calc.total_krl:,}")
         self.card_krd.config(text=f"KRD: Rp{calc.total_krd:,}")
+        if gen_time:
+            self.gen_label.config(text=f"Dibuat: {gen_time}")
 
     def _update_details(self, calc):
         for i in self.tree.get_children():
@@ -138,3 +160,51 @@ class BudgetGUI:
                      labels=['KRL','KRD'], autopct='%1.1f%%')
         self.ax2.set_title('Distribusi KRL vs KRD')
         self.canvas.draw()
+
+    def _save_last(self, calc, saldo, year, month, gen_time):
+        data = {
+            'year': year,
+            'month': month,
+            'saldo': saldo,
+            'generated_at': gen_time,
+            'total_krl': calc.total_krl,
+            'total_krd': calc.total_krd,
+            'daily_logs': [
+                (d.strftime('%Y-%m-%d'), day, krl, krd)
+                for d, day, krl, krd in calc.daily_logs
+            ]
+        }
+        with open(SAVE_FILE, 'w') as f:
+            json.dump(data, f)
+
+    def _load_last(self):
+        if not os.path.exists(SAVE_FILE):
+            return
+        with open(SAVE_FILE) as f:
+            data = json.load(f)
+
+        self.year_cb.set(str(data['year']))
+        self._update_months()
+        self.month_cb.set(str(data['month']))
+        self.saldo_var.set(data.get('saldo', 0))
+
+        class Calc:
+            def __init__(self, d):
+                self.total_krl = d['total_krl']
+                self.total_krd = d['total_krd']
+                self.daily_logs = [
+                    (datetime.strptime(dt, '%Y-%m-%d'), day, krl, krd)
+                    for dt, day, krl, krd in d['daily_logs']
+                ]
+
+            @property
+            def total(self):
+                return self.total_krl + self.total_krd
+
+        calc = Calc(data)
+        gen_time = data.get('generated_at')
+        self._update_summary(calc, data.get('saldo', 0), gen_time)
+        self._update_details(calc)
+        if HAS_MPL:
+            self._update_charts(calc)
+


### PR DESCRIPTION
## Summary
- allow entering KMT balance and subtract it from the calculated total
- display generation date and show final amount after saldo deduction
- remember the last generated data using `last_result.json`
- automatically load the previous result on start

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688843921580832ab07b41877c6fb49c